### PR TITLE
fix: add support for Vaadin 23.3.x

### DIFF
--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSorterFilterComponentRenderer.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/GridSorterFilterComponentRenderer.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.component.grid;
 
+import java.lang.reflect.Method;
+
 /*-
  * #%L
  * Enhanced Grid
@@ -39,9 +41,19 @@ import com.vaadin.flow.dom.Element;
 public class GridSorterFilterComponentRenderer <SOURCE>
 	extends ComponentRenderer<Component, SOURCE>{
 
+	private static final Method setBaseHeaderTemplate = getMethod(EnhancedColumn.class, "setBaseHeaderTemplate").orElse(null);
+	
 	private final EnhancedColumn<?> column;
     private final Component component;
 
+    private static Optional<Method> getMethod(Class<?> clazz, String name) {
+        try {
+          return Optional.of(clazz.getMethod(name));
+        } catch (NoSuchMethodException e) {
+          return Optional.empty();
+        }
+      }
+    
     /**
      * Creates a new renderer for a specific column, using the defined
      * component.
@@ -100,7 +112,10 @@ public class GridSorterFilterComponentRenderer <SOURCE>
          * if/when the sortable state is changed by the developer, the column
          * knows how to add or remove the grid sorter.
          */
-        column.setBaseHeaderTemplate(templateInnerHtml);
+        if(setBaseHeaderTemplate != null) {
+        	column.setBaseHeaderTemplate(templateInnerHtml);
+        }
+        
         if (column.hasSortingIndicators() && !column.isFilterable()) {
             templateInnerHtml = column.addGridSorter(templateInnerHtml);
         }


### PR DESCRIPTION
Added null check to the missing method in Vaadin 23.3.x as it was the only change breaking the component. As it was the only change that causes incompatibility when the component it's used with Vaadin 23.3.x I thought it was better to add a null check instead of releasing a new version of the component with that mininal change.

Close #29