### PR TITLE
Reset the header on attach. 

### DIFF
--- a/enhanced-grid-flow-demo/src/main/java/com/vaadin/componentfactory/enhancedgrid/SimpleSingleSelectView.java
+++ b/enhanced-grid-flow-demo/src/main/java/com/vaadin/componentfactory/enhancedgrid/SimpleSingleSelectView.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.renderer.NumberRenderer;
+import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 
@@ -27,6 +28,7 @@ import com.vaadin.flow.router.RouteAlias;
  */
 @Route(value = "", layout = MainLayout.class)
 @RouteAlias(value = "single-grid", layout = MainLayout.class)
+@PreserveOnRefresh
 public class SimpleSingleSelectView extends Div {
 
     public SimpleSingleSelectView() {

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
@@ -22,6 +22,7 @@ package com.vaadin.componentfactory.enhancedgrid;
 
 import java.util.Comparator;
 
+import com.vaadin.flow.component.AttachEvent;
 import org.apache.commons.lang3.StringUtils;
 
 import com.vaadin.flow.component.Component;
@@ -97,7 +98,11 @@ public class EnhancedColumn<T> extends Grid.Column<T> {
 		if (this.isFilterable()) {
 			this.grid.getElement().executeJs("monkeyPatchHeaderRenderer(this.$connector, $0)", getInternalId());
 		}
-		return (EnhancedColumn<T>) super.setHeader(headerComponent);
+		EnhancedColumn<T> enhancedColumn = (EnhancedColumn<T>) super.setHeader(headerComponent);
+		if(enhancedColumn.getFilter() != null) {
+			enhancedColumn.updateFilterButtonStyle();
+		}
+		return enhancedColumn;
 	}
 
 	/**
@@ -285,4 +290,5 @@ public class EnhancedColumn<T> extends Grid.Column<T> {
 	public EnhancedColumn<T> setKey(String key) {
 		return (EnhancedColumn<T>) super.setKey(key);
 	}
+
 }

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
@@ -544,6 +544,12 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
     protected void onAttach(AttachEvent attachEvent) {
     	super.onAttach(attachEvent);
     	this.updateFilterIcon();
+
+		// Fix missing filter on refresh if @PreserveOnRefresh is used
+		for(Column<T> column : getColumns()) {
+			EnhancedColumn<T> enhancedColumn = (EnhancedColumn<T>)column;
+			Optional.ofNullable(enhancedColumn.getHeaderComponent()).ifPresent(enhancedColumn::setHeader);
+		}
     }
 }
 


### PR DESCRIPTION
Fixes wrong header after browser refresh, when @PreserveOnRefresh is used.