### PR TITLE
Replace popup component with popover component

### DIFF
--- a/enhanced-grid-flow-demo/pom.xml
+++ b/enhanced-grid-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-grid-flow-demo</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <name>Enhanced Grid Demo</name>
     <packaging>war</packaging>
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.0.0</vaadin.version>
+        <vaadin.version>24.5.6</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.14</version>
+                <version>11.0.22</version>
                 <configuration>
                     <scanIntervalSeconds>-1</scanIntervalSeconds>
                     <stopKey>${project.artifactId}</stopKey>

--- a/enhanced-grid-flow/pom.xml
+++ b/enhanced-grid-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-grid-flow</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Enhanced Grid</name>
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.0.0</vaadin.version>
+        <vaadin.version>24.5.6</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -101,11 +101,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-		   <groupId>com.vaadin.componentfactory</groupId>
-		   <artifactId>popup</artifactId>
-		   <version>4.0.0</version>
-		</dependency>
 
     </dependencies>
 

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory.enhancedgrid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedColumn.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.component.grid.FilterFieldDto;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.Grid.Column;
 import com.vaadin.flow.component.grid.SortOrderProvider;
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.data.renderer.Renderer;
@@ -78,8 +77,8 @@ public class EnhancedColumn<T> extends Grid.Column<T> implements BeforeEnterObse
 		if(filter != null) {
 			Component headerComponent = new Span();
 	        headerComponent.getElement().setText(labelText);
-	        addFilterButtonToHeader(headerComponent, filter);		
-	        return setHeader(headerComponent); 
+	        addFilterButtonToHeader(headerComponent, filter);
+	        return setHeader(headerComponent);
 		}		
 		return setHeader(labelText);
     }
@@ -109,41 +108,36 @@ public class EnhancedColumn<T> extends Grid.Column<T> implements BeforeEnterObse
 		return (EnhancedColumn<T>) super.setHeader(labelText);
 	}
 	
-	private void addFilterButtonToHeader(Component headerComponent, HasValueAndElement<?, ? extends FilterFieldDto> filter) {
+	protected void addFilterButtonToHeader(Component headerComponent, HasValueAndElement<?, ? extends FilterFieldDto> filter) {
 		this.filter = filter;
 		this.headerComponent = headerComponent;
                 
         // add filter field (popup component) and set filter as it's filter component
         filterField = new FilterField();
         filterField.addApplyFilterListener(grid);
-        filterField.addFilterComponent(filter.getElement().getComponent().get());
-        
-        filterField.addPopupOpenChangedEventListener(e -> {
+		filter.getElement().getComponent()
+		      .ifPresent(filterComponent -> filterField.addFilterComponent(filterComponent));
+
+        filterField.addOpenedChangeListener(e -> {
            	if(grid.getEditor().getItem() != null) {
            		if(grid.allowCancelEditDialogDisplay()) {
-           			grid.cancelEditWithCancelCallback(() -> filterField.hide());
+           			grid.cancelEditWithCancelCallback(() -> filterField.close());
            		} else {
            			grid.getEditor().cancel();
            		}
            	}  	
         });
         
-        // need to add a not visible component so filterField (popup component) can be open
-        Div div = new Div();
-        div.setId(getInternalId());       
-        div.getElement().getStyle().set("display", "inline-block");
-		filterField.setFor(div.getId().get());		
-		headerComponent.getElement().appendChild(div.getElement());
-
 		// add filter field to header
        	headerComponent.getElement().appendChild(filterField.getElement());
-                
+		filterField.setTarget(headerComponent);
+
         grid.addFilterClickedEventListener(e -> {
            	if(e.buttonId.equals(getInternalId())) {
         		if(filterField.isOpened()) {
-        			filterField.hide();
+        			filterField.close();
         		} else {
-        			filterField.show();
+        			filterField.open();
         		}
         	}
 		});
@@ -153,7 +147,7 @@ public class EnhancedColumn<T> extends Grid.Column<T> implements BeforeEnterObse
 		return filter; 
 	}	
 	
-	void updateFilterButtonStyle(){
+	protected void updateFilterButtonStyle(){
 		if(headerComponent != null) {
 			headerComponent.getElement().executeJs("return").then(ignore -> {
 				if(hasFilterSelected()) {

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory.enhancedgrid;
  * #%L
  * enhanced-grid-flow
  * %%
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedgrid/EnhancedGrid.java
@@ -89,17 +89,12 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
     
     private Icon filterIcon;
     	
-    SerializableFunction<T, String> selectionDisabled = new SerializableFunction<T, String>() {
-
-    	@Override
-		public String apply(T item) {
-			if(!selectionPredicate.test(item)) {
-    			return "selection-disabled";
-    		}
-			return "";
-		}
-    	
-	};
+    SerializableFunction<T, String> selectionDisabled = item -> {
+        if (!selectionPredicate.test(item)) {
+            return "selection-disabled";
+        }
+        return "";
+    };
 
     private SerializableFunction<T, String> defaultClassNameGenerator = item -> null;
 
@@ -229,6 +224,16 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
             GridSelectionModel<T> model = new CustomAbstractGridMultiSelectionModel<T>(this) {
 
                 @Override
+                public void setDragSelect(boolean b) {
+					// Do nothing
+                }
+
+                @Override
+                public boolean isDragSelect() {
+                    return false;
+                }
+
+                @Override
                 protected void fireSelectionEvent(SelectionEvent<Grid<T>, T> event) {
                     ComponentUtil.fireEvent(getGrid(), (ComponentEvent<Grid<?>>) event);
                 }
@@ -289,11 +294,11 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
     	}
 
         T onEditItem = this.getEditor().getItem();    	    	
-    	if(onEditItem != null && item.equals(onEditItem)) {
+    	if(item.equals(onEditItem)) {
     		return;
     	}
     	
-		if(onEditItem != null && !item.equals(onEditItem) && allowCancelEditDialogDisplay()) {
+		if(onEditItem != null && allowCancelEditDialogDisplay()) {
 			cancelEditItem(item, null, null);
 		} else {
 			this.getEditor().editItem(item);
@@ -328,7 +333,13 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
 			}
     	}      
     }
-    
+
+	/**
+	 * Cancel the edition of the item.
+	 * @param newEditItem - the new item to edit
+	 * @param action - the action to proceed
+	 * @param onCancelCallback - the callback to execute on cancel action
+	 */
     protected void cancelEditItem(T newEditItem, ContinueNavigationAction action, SerializableRunnable onCancelCallback) {
     	String text = getTranslation(CANCEL_EDIT_MSG_KEY);
     	String confirmText = getTranslation(CANCEL_EDIT_CONFIRM_BTN_KEY); 
@@ -337,14 +348,24 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
        	new CancelEditConfirmDialog(text, confirmText, cancelText, onConfirmCallback, onCancelCallback).open();
     }
 
-    private void onConfirmEditItem(T newEditItem) {
+	/**
+	 * Confirm the edition of the item.
+	 * @param newEditItem - the new item to edit
+	 */
+    protected void onConfirmEditItem(T newEditItem) {
     	this.getEditor().cancel();
 		if(newEditItem != null) {
 			this.getEditor().editItem(newEditItem);
 		}
     }
 
-    private void onConfirmEditItem(T newEditItem, ContinueNavigationAction action) {
+	/**
+	 * Confirm the edition of the item.
+	 *
+	 * @param newEditItem - the new item to edit
+	 * @param action - the action to proceed
+	 */
+	protected void onConfirmEditItem(T newEditItem, ContinueNavigationAction action) {
     	this.onConfirmEditItem(null);
     	action.proceed();
     }
@@ -352,7 +373,7 @@ public class EnhancedGrid<T> extends Grid<T> implements BeforeLeaveObserver, App
 	/**
 	 * Set showCancelEditDialog value to know if {@link CancelEditConfirmDialog} should be displayed.
 	 *
-	 * @param showCancelEditDialog
+	 * @param showCancelEditDialog - the value to set
 	 */
 	public void setShowCancelEditDialog(boolean showCancelEditDialog) {
 		this.showCancelEditDialog = showCancelEditDialog;

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedtreegrid/EnhancedHierarchyColumnComponentRenderer.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedtreegrid/EnhancedHierarchyColumnComponentRenderer.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory.enhancedtreegrid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2023 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedtreegrid/EnhancedTreeGrid.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/componentfactory/enhancedtreegrid/EnhancedTreeGrid.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory.enhancedtreegrid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/ApplyFilterListener.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/ApplyFilterListener.java
@@ -4,7 +4,7 @@ package com.vaadin.flow.component.grid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CancelEditConfirmDialog.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CancelEditConfirmDialog.java
@@ -4,7 +4,7 @@ package com.vaadin.flow.component.grid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CustomAbstractGridMultiSelectionModel.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CustomAbstractGridMultiSelectionModel.java
@@ -2,9 +2,9 @@ package com.vaadin.flow.component.grid;
 
 /*-
  * #%L
- * Custom Grid
+ * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CustomAbstractGridSingleSelectionModel.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/CustomAbstractGridSingleSelectionModel.java
@@ -1,25 +1,10 @@
-/*
- * Copyright 2000-2017 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package com.vaadin.flow.component.grid;
 
 /*-
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/Filter.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/Filter.java
@@ -1,12 +1,10 @@
 package com.vaadin.flow.component.grid;
 
-import com.vaadin.componentfactory.enhancedgrid.EnhancedGrid;
-
 /*-
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +20,7 @@ import com.vaadin.componentfactory.enhancedgrid.EnhancedGrid;
  * #L%
  */
 
+import com.vaadin.componentfactory.enhancedgrid.EnhancedGrid;
 import com.vaadin.flow.function.SerializablePredicate;
 
 /**

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterClickedEvent.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterClickedEvent.java
@@ -20,7 +20,7 @@ package com.vaadin.flow.component.grid;
  * #L%
  */
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 
 import com.vaadin.componentfactory.enhancedgrid.EnhancedGrid;
 import com.vaadin.flow.component.ComponentEvent;
@@ -34,10 +34,9 @@ import com.vaadin.flow.component.EventData;
 @DomEvent("filter-clicked")
 public class FilterClickedEvent<T> extends ComponentEvent<EnhancedGrid<T>> {
 
-	@NotNull
 	public final String buttonId;
 	
-	public FilterClickedEvent(EnhancedGrid<T> source, boolean fromClient, @EventData("event.detail.id") @NotNull String id) {
+	public FilterClickedEvent(EnhancedGrid<T> source, boolean fromClient, @EventData("event.detail.id") @Nonnull String id) {
 		super(source, fromClient);
 		this.buttonId = id;
 	}

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterClickedEvent.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterClickedEvent.java
@@ -4,7 +4,7 @@ package com.vaadin.flow.component.grid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterField.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterField.java
@@ -22,7 +22,6 @@ import java.util.Optional;
  * #L%
  */
 
-import com.vaadin.componentfactory.Popup;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;
@@ -31,8 +30,9 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.popover.Popover;
 
-public class FilterField extends Popup {
+public class FilterField extends Popover {
 	
 	private static final String APPLY_BTN_KEY = "filter-field.apply.btn";
 	
@@ -55,6 +55,14 @@ public class FilterField extends Popup {
 		rootLayout.add(filterComponentDiv, createButtonsLayout());
 		add(rootLayout);
 		getElement().getThemeList().add("enhanced-grid-filter-field");
+
+		setOpenOnClick(false);
+		setOpenOnFocus(true);
+		setOpenOnHover(false);
+
+		setCloseOnOutsideClick(true);
+		setCloseOnEsc(true);
+		setAutofocus(true);
 	}
 		
 	private HorizontalLayout createButtonsLayout() {
@@ -71,7 +79,7 @@ public class FilterField extends Popup {
 
 	public void applyFilter() {
 		applyFilterListener.onApplyFilter(((HasValue<?,?>)filterComponent).getValue());		
-		this.hide();
+		this.close();
 	}
 
 	public void resetFilter() {

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterField.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterField.java
@@ -1,12 +1,10 @@
 package com.vaadin.flow.component.grid;
 
-import java.util.Optional;
-
 /*-
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +20,7 @@ import java.util.Optional;
  * #L%
  */
 
+import java.util.Optional;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;

--- a/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterFieldDto.java
+++ b/enhanced-grid-flow/src/main/java/com/vaadin/flow/component/grid/FilterFieldDto.java
@@ -4,7 +4,7 @@ package com.vaadin.flow.component.grid;
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/enhanced-grid-flow/src/main/resources/META-INF/resources/frontend/src/enhanced-grid-sorter.js
+++ b/enhanced-grid-flow/src/main/resources/META-INF/resources/frontend/src/enhanced-grid-sorter.js
@@ -2,7 +2,7 @@
  * #%L
  * Enhanced Grid
  * %%
- * Copyright (C) 2020 - 2021 Vaadin Ltd
+ * Copyright (C) 2020 - 2024 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-grid-flow-root</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>enhanced-grid-flow</module>
@@ -13,7 +13,7 @@
     <description>enhanced-grid-flow</description>
 
     <properties>
-        <vaadin.version>24.0.0</vaadin.version>
+        <vaadin.version>24.5.6</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Close #41.

This PR includes changes made in #40. 

As replacing the popup component by using popover component is a breaking change, version was updated to 5.0.0-SNAPSHOT.